### PR TITLE
fix: skip failed opset calculators instead of aborting entire stake table computation

### DIFF
--- a/pkg/operatorTableCalculator/operatorTableCalculator.go
+++ b/pkg/operatorTableCalculator/operatorTableCalculator.go
@@ -101,18 +101,20 @@ func (c *StakeTableCalculator) CalculateStakeTableRoot(
 		return zeroRoot, nil, dist, nil
 	}
 
-	distributionOpsets := util.Map(opsetsWithCalculators, func(opset ICrossChainRegistry.OperatorSet, i uint64) distribution.OperatorSet {
+	allOpsets := util.Map(opsetsWithCalculators, func(opset ICrossChainRegistry.OperatorSet, i uint64) distribution.OperatorSet {
 		return distribution.OperatorSet{
 			Id:  opset.Id,
 			Avs: opset.Avs,
 		}
 	})
 
-	dist.SetOperatorSets(distributionOpsets)
+	// Calculate table bytes for each opset, skipping any whose calculator reverts.
+	// A single malicious/broken AVS calculator must not block all other opsets.
+	var successfulOpsets []distribution.OperatorSet
+	var opsetTableRoots [][]byte
+	var opsetTableBytes [][]byte
 
-	opsetTableRoots := make([][]byte, len(opsetsWithCalculators))
-	for i, opset := range distributionOpsets {
-		// get the table bytes for the operator set
+	for i, opset := range allOpsets {
 		c.logger.Sugar().Infow("Calculating operator table bytes for opset",
 			zap.Uint32("opsetId", opset.Id),
 			zap.String("opsetAvs", opset.Avs.String()),
@@ -123,9 +125,10 @@ func (c *StakeTableCalculator) CalculateStakeTableRoot(
 			BlockNumber: new(big.Int).SetUint64(referenceBlockNumber),
 		}, opsetsWithCalculators[i])
 		if err != nil {
-			c.logger.Sugar().Errorw("Failed to calculate operator table bytes",
+			c.logger.Sugar().Errorw("Skipping opset: CalculateOperatorTableBytes reverted",
 				zap.Uint32("opsetId", opset.Id),
 				zap.String("opsetAvs", opset.Avs.String()),
+				zap.Error(err),
 			)
 			continue
 		}
@@ -136,15 +139,33 @@ func (c *StakeTableCalculator) CalculateStakeTableRoot(
 		)
 
 		encodedLeaf := distribution.EncodeOperatorTableLeaf(tableBytes)
-		opsetTableRoots[i] = encodedLeaf
-
 		c.logger.Sugar().Infow("Encoded operator table leaf for opset",
 			zap.Uint32("opsetId", opset.Id),
 			zap.String("opsetAvs", opset.Avs.String()),
 			zap.String("encodedLeaf", hexutil.Encode(encodedLeaf)),
 		)
 
-		err = dist.SetTableData(opset, tableBytes)
+		successfulOpsets = append(successfulOpsets, opset)
+		opsetTableRoots = append(opsetTableRoots, encodedLeaf)
+		opsetTableBytes = append(opsetTableBytes, tableBytes)
+	}
+
+	if len(successfulOpsets) == 0 {
+		c.logger.Sugar().Warnw("All operator set calculators failed, global table root will be zero.")
+		return zeroRoot, nil, dist, nil
+	}
+
+	if len(successfulOpsets) < len(allOpsets) {
+		c.logger.Sugar().Warnw("Some operator set calculators failed, proceeding with successful ones only",
+			zap.Int("total", len(allOpsets)),
+			zap.Int("successful", len(successfulOpsets)),
+			zap.Int("failed", len(allOpsets)-len(successfulOpsets)),
+		)
+	}
+
+	dist.SetOperatorSets(successfulOpsets)
+	for i, opset := range successfulOpsets {
+		err = dist.SetTableData(opset, opsetTableBytes[i])
 		if err != nil {
 			return zeroRoot, nil, nil, fmt.Errorf("failed to set table data for opset %d: %w", opset, err)
 		}

--- a/pkg/operatorTableCalculator/operatorTableCalculator_test.go
+++ b/pkg/operatorTableCalculator/operatorTableCalculator_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/Layr-Labs/eigenlayer-contracts/pkg/bindings/ICrossChainRegistry"
 	"github.com/Layr-Labs/multichain-go/pkg/chainManager"
+	"github.com/Layr-Labs/multichain-go/pkg/distribution"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/assert"
@@ -295,6 +296,114 @@ func TestNewStakeTableRootCalculatorWithRegistryCaller_NilConfig(t *testing.T) {
 	assert.Equal(t, mockEthClient, calculator.ethClient)
 	assert.Equal(t, logger, calculator.logger)
 	assert.Equal(t, mockRegistryCaller, calculator.crossChainRegistryCaller)
+}
+
+// TestMaliciousAVS_RevertingCalculator_SkippedWithoutBlockingOthers demonstrates
+// that a malicious AVS whose CalculateOperatorTableBytes reverts is skipped,
+// while all legitimate operator sets are still included in the stake table.
+func TestMaliciousAVS_RevertingCalculator_SkippedWithoutBlockingOthers(t *testing.T) {
+	calculator, mockRegistryCaller, _ := setupTestCalculator(t)
+
+	blockNumber := uint64(12345)
+	callOpts := &bind.CallOpts{
+		Context:     context.Background(),
+		BlockNumber: new(big.Int).SetUint64(blockNumber),
+	}
+
+	// 3 legitimate AVSes + 1 malicious AVS
+	legitimateAvs1 := common.HexToAddress("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+	legitimateAvs2 := common.HexToAddress("0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
+	maliciousAvs := common.HexToAddress("0xdeaddeaddeaddeaddeaddeaddeaddeaddeaddead")
+	legitimateAvs3 := common.HexToAddress("0xcccccccccccccccccccccccccccccccccccccccc")
+
+	allOpsets := []ICrossChainRegistry.OperatorSet{
+		{Avs: legitimateAvs1, Id: 1},
+		{Avs: legitimateAvs2, Id: 2},
+		{Avs: maliciousAvs, Id: 3}, // malicious — calculator reverts
+		{Avs: legitimateAvs3, Id: 4},
+	}
+
+	// Mock pagination: return all 4 opsets
+	mockRegistryCaller.On("GetActiveGenerationReservationCount", callOpts).
+		Return(big.NewInt(4), nil)
+	mockRegistryCaller.On("GetActiveGenerationReservationsByRange", callOpts, big.NewInt(0), big.NewInt(4)).
+		Return(allOpsets, nil)
+
+	// Legitimate AVSes return valid table bytes
+	mockRegistryCaller.On("CalculateOperatorTableBytes", callOpts, allOpsets[0]).
+		Return([]byte{0x01, 0x02, 0x03}, nil)
+	mockRegistryCaller.On("CalculateOperatorTableBytes", callOpts, allOpsets[1]).
+		Return([]byte{0x04, 0x05, 0x06}, nil)
+	mockRegistryCaller.On("CalculateOperatorTableBytes", callOpts, allOpsets[3]).
+		Return([]byte{0x0a, 0x0b, 0x0c}, nil)
+
+	// Malicious AVS: calculator reverts
+	mockRegistryCaller.On("CalculateOperatorTableBytes", callOpts, allOpsets[2]).
+		Return([]byte(nil), errors.New("execution reverted"))
+
+	root, tree, dist, err := calculator.CalculateStakeTableRoot(context.Background(), blockNumber)
+
+	// Calculation succeeds despite the malicious AVS
+	require.NoError(t, err)
+	assert.NotEqual(t, [32]byte{}, root)
+	assert.NotNil(t, tree)
+	assert.NotNil(t, dist)
+
+	// Only 3 legitimate opsets are in the distribution — malicious one is excluded
+	opsets := dist.GetOrderedOperatorSets()
+	assert.Len(t, opsets, 3)
+
+	// Verify the 3 legitimate opsets are present with correct indices
+	assert.Equal(t, distribution.OperatorSet{Id: 1, Avs: legitimateAvs1}, opsets[0])
+	assert.Equal(t, distribution.OperatorSet{Id: 2, Avs: legitimateAvs2}, opsets[1])
+	assert.Equal(t, distribution.OperatorSet{Id: 4, Avs: legitimateAvs3}, opsets[2])
+
+	// Verify table data exists for each legitimate opset
+	for _, opset := range opsets {
+		_, found := dist.GetTableData(opset)
+		assert.True(t, found, "table data should exist for opset %v", opset)
+	}
+
+	// Verify the malicious AVS is NOT in the distribution
+	_, found := dist.GetTableIndex(distribution.OperatorSet{Id: 3, Avs: maliciousAvs})
+	assert.False(t, found, "malicious AVS should not be in distribution")
+}
+
+// TestAllCalculatorsFail_ReturnsZeroRoot verifies that if every opset's
+// calculator reverts, the result is a zero root (not an error).
+func TestAllCalculatorsFail_ReturnsZeroRoot(t *testing.T) {
+	calculator, mockRegistryCaller, _ := setupTestCalculator(t)
+
+	blockNumber := uint64(12345)
+	callOpts := &bind.CallOpts{
+		Context:     context.Background(),
+		BlockNumber: new(big.Int).SetUint64(blockNumber),
+	}
+
+	allOpsets := []ICrossChainRegistry.OperatorSet{
+		{Avs: common.HexToAddress("0xdeaddeaddeaddeaddeaddeaddeaddeaddeaddead"), Id: 1},
+		{Avs: common.HexToAddress("0xbaadbaadbaadbaadbaadbaadbaadbaadbaadbAAD"), Id: 2},
+	}
+
+	mockRegistryCaller.On("GetActiveGenerationReservationCount", callOpts).
+		Return(big.NewInt(2), nil)
+	mockRegistryCaller.On("GetActiveGenerationReservationsByRange", callOpts, big.NewInt(0), big.NewInt(2)).
+		Return(allOpsets, nil)
+
+	// Both calculators revert
+	mockRegistryCaller.On("CalculateOperatorTableBytes", callOpts, allOpsets[0]).
+		Return([]byte(nil), errors.New("execution reverted"))
+	mockRegistryCaller.On("CalculateOperatorTableBytes", callOpts, allOpsets[1]).
+		Return([]byte(nil), errors.New("execution reverted"))
+
+	root, tree, dist, err := calculator.CalculateStakeTableRoot(context.Background(), blockNumber)
+
+	// Should succeed with zero root, not error
+	require.NoError(t, err)
+	assert.Equal(t, [32]byte{}, root)
+	assert.Nil(t, tree)
+	assert.NotNil(t, dist)
+	assert.Empty(t, dist.GetOperatorSets())
 }
 
 func TestStakeTableCalculatorConfig_Validation(t *testing.T) {


### PR DESCRIPTION
## Summary

- A single malicious/broken AVS calculator contract that reverts on `CalculateOperatorTableBytes` was able to block the entire stake table computation, preventing all operator sets across all chains from being updated
- Failed opset calculators are now skipped with clear logging, and the Merkle tree is built from only the successful opsets
- If all calculators fail, the function returns a zero root (same as empty opset case) rather than erroring

## What changed

**`pkg/operatorTableCalculator/operatorTableCalculator.go`**
- Calculate table bytes for each opset independently, collecting successes
- Skip reverts with `ERROR` log (includes AVS address + error)
- `WARN` summary when some calculators fail (total/successful/failed counts)
- Build Merkle tree and distribution from successful opsets only

**`pkg/operatorTableCalculator/operatorTableCalculator_test.go`**
- `TestMaliciousAVS_RevertingCalculator_SkippedWithoutBlockingOthers`: 3 legitimate + 1 malicious AVS → calculation succeeds with only the 3 legitimate opsets
- `TestAllCalculatorsFail_ReturnsZeroRoot`: all calculators revert → zero root, no error

## Test plan

- [x] All existing tests pass
- [x] New test: malicious AVS is skipped, legitimate opsets still included
- [x] New test: all calculators fail → zero root returned
- [x] `make test` passes